### PR TITLE
Uncomment install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,13 @@ except FileNotFoundError:
     long_description = DESCRIPTION
 
 REQUIRED = [
-    # 'opencv-python',
-    # 'numpy',
-    # 'matplotlib',
-    # 'skimage.io',
-    # 'tifffile',
-    # 'tqdm',
+    'opencv-python',
+    'numpy',
+    'matplotlib',
+    'skimage.io',
+    'tifffile',
+    'tqdm',
+    'Pillow'
 ]
 
 setup(


### PR DESCRIPTION
When I tried to prepare a development environment for PR, I couldn't install the necessary libraries in `pip install -e .`.